### PR TITLE
Use LineageOS teal color as accent

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 export default {
     OS_NAME: process.env.VUE_APP_OS_NAME,
-    ACCENT_COLOR: "#0366d6",
+    ACCENT_COLOR: "#167C80",
     SUPPORTED_DEVICES: [
         {
             name: "Teracube 2e",


### PR DESCRIPTION
This is the color used on LineageOS branding, LineageOS's websites, and within LineageOS itself, meaning it makes sense to use it here too.